### PR TITLE
Update convert_alignment.py to support BioPython < 1.44

### DIFF
--- a/scripts/convert_alignment.py
+++ b/scripts/convert_alignment.py
@@ -11,7 +11,7 @@ import Bio.SeqIO
 
 def convert(f_in, format, f_out):
     for record in Bio.SeqIO.parse(f_in, format):
-        f_out.write(record.seq.tostring())
+        f_out.write(str(record.seq))
         f_out.write("\n")
 
 

--- a/scripts/convert_alignment.py
+++ b/scripts/convert_alignment.py
@@ -11,7 +11,10 @@ import Bio.SeqIO
 
 def convert(f_in, format, f_out):
     for record in Bio.SeqIO.parse(f_in, format):
-        f_out.write(str(record.seq))
+        try:
+            f_out.write(record.seq.tostring())
+        except AttributeError:
+            f_out.write(str(record.seq))
         f_out.write("\n")
 
 


### PR DESCRIPTION
I have been recently using the convert_alignment.py script to convert some FASTA files, however it was failing because the tostring() method.

Update to string parsing method to conform to new Seq class - https://biopython.org/DIST/docs/api/Bio.Seq.Seq-class.html

