### PR TITLE
Export of raw parameters as numpy array, plus some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ When doing computations on the GPU, the available memory limits the size of the 
 
 You can calculate the memory requirements in bytes for L columns and N rows using the following formula:
 
-	4*(4*(L*L*21*21 + L*20) + 23*N*L + N + L*L) + 2*N*L + 1024
+	4*(4*(L*L*21*21 + L*20) + 23*N*L + N) + 2*N*L
 
 For the padded version:
 
-	4*(4*(L*L*32*21 + L*20) + 23*N*L + N + L*L) + 2*N*L + 1024
+	4*(4*(L*L*32*21 + L*20) + 34*N*L + N) + 2*N*L
 
 ## Installation
 We recommend compiling CCMpred on the machine that should run the computations so that it can be optimized for the appropriate CPU/GPU architecture.

--- a/include/evaluate_cuda_kernels.h
+++ b/include/evaluate_cuda_kernels.h
@@ -6,7 +6,7 @@
 #include "evaluate_cuda.h"
 #include "ccmpred.h"
 
-#define CHECK_ERR(err) {if (cudaSuccess != (err)) { printf("CUDA error No. %d in %s at line %d\n", (err), __FILE__, __LINE__); exit(EXIT_FAILURE); } }
+#define CHECK_ERR(err) {int e = (err); if (cudaSuccess != e) { printf("CUDA error No. %d in %s at line %d\n", e, __FILE__, __LINE__); exit(EXIT_FAILURE); } }
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/io.h
+++ b/include/io.h
@@ -21,6 +21,15 @@ void write_matrix(FILE *out, conjugrad_float_t *mat, int ncol, int nrow);
 void write_raw(FILE *out, conjugrad_float_t *x, int ncol);
 
 /**
+ * Write out raw MRF data to a file descriptor as a numpy array
+ *
+ * @param[in] out The file handle to write to
+ * @param[in] x The parameters of the MRF to write out
+ * @param[in] ncol The number of columns in the underlying MSA
+ */
+void write_raw_numpy(FILE *out, conjugrad_float_t *x, int ncol);
+
+/**
  * Read initial weights from a file.
  *
  * @param[in] filename The file name to read from

--- a/src/io.c
+++ b/src/io.c
@@ -59,6 +59,62 @@ void write_raw(FILE *out, conjugrad_float_t *x, int ncol) {
 	}
 }
 
+void write_raw_numpy(FILE *out, conjugrad_float_t *x, int ncol) {
+
+    int nsingle = ncol * (N_ALPHA - 1);
+    int nsingle_padded = nsingle + N_ALPHA_PAD - (nsingle % N_ALPHA_PAD);
+
+    conjugrad_float_t *x1 = x;
+    //conjugrad_float_t *x2 = &x[nsingle];
+    conjugrad_float_t *x2 = &x[nsingle_padded];
+    (void)x2;
+
+    // Write magic code
+    char magic[6] = {'\x93', '\x4E', '\x55', '\x4D', '\x50', '\x59'};
+    fwrite(magic, 1, 6, out);
+
+    // Write version information
+    char version[2] = {0x01, 0x00};
+    fwrite(version, 1, 2, out);
+
+    int digits = 0;
+    int num = ncol;
+    while (num != 0) {
+        digits++;
+        num /= 10;
+    }
+
+    // Determine padded header size
+    char header[200];
+    int dict_len = snprintf(header, 200, "{'descr': '<f4', 'fortran_order': False, 'shape': (441, %d, %d), }", ncol, ncol);
+    int temp_len = 6 + 2 + 2 + dict_len + 1; // magic + version + header_length + dict + 0x0A;
+    short padding = 0;
+    short r = temp_len % 64;
+    if (r != 0)
+        padding = 64 - r;
+    short header_length = dict_len + padding + 1;
+
+    // Write header length, the header itself, padding and terminating character
+    fwrite(&header_length, 2, 1, out);
+    fwrite(header, 1, dict_len, out);
+    char pad = '\x20';
+    for (int i=0 ; i<padding ; ++i)
+        fwrite(&pad, 1, 1, out);
+    char terminator = '\x0A';
+    fwrite(&terminator, 1, 1, out);
+
+    // Write parameters in C-contiguous order
+    for(int a = 0; a < N_ALPHA; a++) {
+        for(int b = 0; b < N_ALPHA; b++) {
+            for(int i = 0; i < ncol; i++) {
+                for(int j = 0; j < ncol; j++) {
+                    fwrite(&W(b,j,a,i), 4, 1, out);
+                }
+            }
+        }
+    }
+}
+
 void read_raw(char *filename, userdata *ud, conjugrad_float_t *x) {
 	FILE *f = fopen(filename, "r");
 	char *line = (char*) malloc(sizeof(char) * 8192);

--- a/src/meta.c
+++ b/src/meta.c
@@ -1,5 +1,6 @@
 #include <time.h>
 #include <stdlib.h>
+#include <libgen.h>
 
 #ifdef UUID
 #include <uuid/uuid.h>


### PR DESCRIPTION
A common usage scenario for plmDCA nowadays is to use the raw Potts model parameters as an input for machine learning devices, especially Deep Learning systems, to infer contact or distance maps. The most recent and prominent example would be DeepMind's AlphaFold, the winner of CASP13.
CCMpred is widely used because of its GPU acceleration, but has the drawback of outputting the raw parameters as a text file, which can be huge (>10 GB) for longer proteins. Machine learning systems almost always expect numpy arrays as inputs, which are binary representations and therefore also faster to load since they are more compact.

I've implemented the option to directly write the raw paramters to numpy arrays with the command line switch '-y'. This circumvents the additional step of parsing the text output to generate a binary representation.
For long proteins, this makes a huge difference: On a TeslaV100, a MSA with 50k sequences of a protein with 820 residues took **26m13s** to process in the traditional way (CCMpred -> raw text file -> parsing file to generate numpy array), whereas running CCMpred and directly writing a numpy array with my implementation took only **16m20s**.
The speedups are not quite as remarkable for smaller proteins around the average lengths of 200-300 residues, but still account for 1-2 minutes saved per sample. For my current dataset, which contains ~80k MSAs, I expect to save multiple weeks of computation time.

Since I assume that CCMpred is used for exactly this kind of workflow in many structure prediction research projects, I kindly invite you to integrate this addition into the main repository.